### PR TITLE
Add version to the manifest so it became visible at the web ui

### DIFF
--- a/source/DruidOidcExtension/pom.xml
+++ b/source/DruidOidcExtension/pom.xml
@@ -218,6 +218,20 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                        <manifestEntries>
+                            <Implementation-Title>${project.artifactId}</Implementation-Title>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.6</version>
                 <configuration>


### PR DESCRIPTION
*Description of changes:*

Version added to the jar plugin, and web ui can now access and display it

### Before: 
![image](https://github.com/user-attachments/assets/85ee17eb-735e-4df5-841a-f0f07dc0c7a6)
### After:
![image](https://github.com/user-attachments/assets/1f04ec9f-4656-482a-bbe9-f6fcd4deea7b)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
